### PR TITLE
fix(docs): 修改交互式应用HTML表单默认值配置名为defaultValue

### DIFF
--- a/.changeset/luminous-owl-update.md
+++ b/.changeset/luminous-owl-update.md
@@ -1,0 +1,5 @@
+---
+"@scow/docs": patch
+---
+
+修改交互式应用 HTML 表单配置默认值的变量名为 defaultValue

--- a/docs/docs/deploy/config/portal/apps/configure-attributes.md
+++ b/docs/docs/deploy/config/portal/apps/configure-attributes.md
@@ -119,7 +119,7 @@ attributes:
 | `name`     | 字符串                          | 是    | HTML表单的name属性，在编程中使用，并且会作为计算节点环境变量名，可以在Web应用的`script`或者VNC应用的`xstartop`使用 |
 | `label`    | 字符串                          | 是    | HTML表单的label属性，输入框左侧显示的标签                                                 |
 | `required` | 布尔类型                         | 否    | 如果设置为`true`，用户必须填写此项，如果为`false`，用户可以不填，默认为`true`。                        |
-| `default` | 字符串或者数字                         | 否    | 表单的默认值，`number`类型的默认值必须设置为数字。对于`select`类型的表单，如果没有配置`default`，则默认值为第一项                      |
+| `defaultValue` | 字符串或者数字                | 否    | 表单的默认值，`number`类型的默认值必须设置为数字。对于`select`类型的表单，如果没有配置`defaultValue`，则默认值为第一项                      |
 | `placeholder`   | 字符串                        | 否    | 描述输入字段预期值的提示信息，提示用户此处的输入                                                  |
 | `select`   | 选项的列表                        | 否    | 如果`type`是`select`，必须配置此项，指明具体的选项，具体配置办法见`select`示例                        |
 
@@ -144,7 +144,7 @@ attributes:
     name: version
     label: 版本
     required: false
-    defalt: v3.4.0
+    defaultValue: v3.4.0
 ```
 
 ### 配置输入类型为数字的HTML表单
@@ -167,7 +167,7 @@ attributes:
     name: size
     label: 数量
     required: false
-    default: 123
+    defaultValue: 123
 ```
 
 ### 配置输入为下拉选择器的HTML表单


### PR DESCRIPTION
### 做了什么

修改文档中记载的属性名，由 default 修改为 defaultValue
已确认其他关于交互式应用HTML表单配置的地方没有此属性名称错误