### PR TITLE
fix(cli): 修复./cli compose run {container} {args}中arg没有传递给容器的问题

### DIFF
--- a/.changeset/silent-tomatoes-attend.md
+++ b/.changeset/silent-tomatoes-attend.md
@@ -1,0 +1,5 @@
+---
+"@scow/cli": patch
+---
+
+修复 cli compose run 命令时命令行参数没有传给容器的问题

--- a/.changeset/silent-tomatoes-attend.md
+++ b/.changeset/silent-tomatoes-attend.md
@@ -1,5 +1,6 @@
 ---
 "@scow/cli": patch
+"@scow/docs": patch
 ---
 
 修复 cli compose run 命令时命令行参数没有传给容器的问题

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,4 +5,5 @@ cd "apps/$SCOW_LAUNCH_APP"
 cp ../../version.json ./
 
 # exec to listen for stop signal
-exec npm run serve
+# also pass all command parameters
+exec npm run serve "$@"

--- a/docs/docs/info/mis/business/billing.mdx
+++ b/docs/docs/info/mis/business/billing.mdx
@@ -159,9 +159,9 @@ tenant_1: # 对租户tenant_1的账户用户发起的任务，在默认规则的
 1. 每个计费项应该只出现一次。即使多个QOS费用相同，也应该定义两个计费项
 2. 数据库中不存在具有相同计费项名的行
 
-在数据库正在运行、`docker-compose.yml`配置编写完成的条件下，运行以下命令快速在数据库中创建费用项信息：
+在数据库正在运行时、运行以下命令快速在数据库中创建费用项信息：
 
 ```bash
-docker compose run mis-server createPriceItems
+./cli compose run mis-server createPriceItems
 ```
 


### PR DESCRIPTION
修复某次升级导致`./cli compose run {container} {args}`中arg没有传递给容器的问题