### PR TITLE
feat(portal,ai): 删除文件管理下的前进和后退按钮

### DIFF
--- a/.changeset/strong-tips-smell.md
+++ b/.changeset/strong-tips-smell.md
@@ -1,0 +1,6 @@
+---
+"@scow/portal-web": patch
+"@scow/ai": patch
+---
+
+删除了文件管理下的前进和后退按钮

--- a/apps/ai/src/app/(auth)/files/FileManager.tsx
+++ b/apps/ai/src/app/(auth)/files/FileManager.tsx
@@ -11,9 +11,8 @@
  */
 
 import { CopyOutlined, DatabaseOutlined, DeleteOutlined, EyeInvisibleOutlined, EyeOutlined,
-  FileAddOutlined, FolderAddOutlined, HomeOutlined, LeftOutlined, MacCommandOutlined,
-  RightOutlined, ScissorOutlined, SnippetsOutlined, UploadOutlined,
-  UpOutlined } from "@ant-design/icons";
+  FileAddOutlined, FolderAddOutlined, HomeOutlined, MacCommandOutlined,
+  ScissorOutlined, SnippetsOutlined, UploadOutlined, UpOutlined } from "@ant-design/icons";
 import { getI18nConfigCurrentText } from "@scow/lib-web/build/utils/systemLanguage";
 import type { inferRouterOutputs } from "@trpc/server";
 import { App, Button, Divider, Modal, Space } from "antd";
@@ -111,14 +110,6 @@ export const FileManager: React.FC<Props> = ({ cluster, loginNodes, path, urlPre
 
   const toHome = () => {
     router.push(fullUrl("~"));
-  };
-
-  const back = () => {
-    router.back();
-  };
-
-  const forward = () => {
-    history.forward();
   };
 
   useEffect(() => {
@@ -273,8 +264,6 @@ export const FileManager: React.FC<Props> = ({ cluster, loginNodes, path, urlPre
         </span>
       </TitleText>
       <TopBar>
-        <Button onClick={back} icon={<LeftOutlined />} shape="circle" />
-        <Button onClick={forward} icon={<RightOutlined />} shape="circle" />
         <Button onClick={toHome} icon={<HomeOutlined />} shape="circle" />
         <Button onClick={up} icon={<UpOutlined />} shape="circle" />
         <PathBar

--- a/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
+++ b/apps/portal-web/src/pageComponents/filemanager/FileManager.tsx
@@ -11,11 +11,8 @@
  */
 
 import {
-  CopyOutlined,
-  DatabaseOutlined,
-  DeleteOutlined, EyeInvisibleOutlined,
-  EyeOutlined, FileAddOutlined, FolderAddOutlined,
-  HomeOutlined, LeftOutlined, MacCommandOutlined, RightOutlined,
+  CopyOutlined, DatabaseOutlined, DeleteOutlined, EyeInvisibleOutlined,
+  EyeOutlined, FileAddOutlined, FolderAddOutlined, HomeOutlined, MacCommandOutlined,
   ScissorOutlined, SnippetsOutlined, UploadOutlined, UpOutlined,
 } from "@ant-design/icons";
 import { DEFAULT_PAGE_SIZE } from "@scow/lib-web/build/utils/pagination";
@@ -159,15 +156,6 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix, scowdEn
   const toHome = () => {
     router.push(fullUrl("~"));
   };
-
-  const back = () => {
-    router.back();
-  };
-
-  const forward = () => {
-    history.forward();
-  };
-
 
   useEffect(() => {
     if (path === "~") {
@@ -374,8 +362,6 @@ export const FileManager: React.FC<Props> = ({ cluster, path, urlPrefix, scowdEn
         </span>
       </TitleText>
       <TopBar>
-        <Button onClick={back} icon={<LeftOutlined />} shape="circle" />
-        <Button onClick={forward} icon={<RightOutlined />} shape="circle" />
         <Button onClick={toHome} icon={<HomeOutlined />} shape="circle" />
         <Button onClick={up} icon={<UpOutlined />} shape="circle" />
         <PathBar


### PR DESCRIPTION
### 做了什么

移除了OpenScow页面下文件管理中的前进后退按钮

### 修改后
<img width="1103" alt="image" src="https://github.com/user-attachments/assets/926c945e-ea61-4301-b080-5712686338e4" />
