### PR TITLE
fix: 修复 ai 模块的 CI 构建错误

### DIFF
--- a/apps/ai/src/server/trpc/route/jobs/apps.ts
+++ b/apps/ai/src/server/trpc/route/jobs/apps.ts
@@ -12,7 +12,7 @@
 
 import { asyncClientCall } from "@ddadaal/tsgrpc-client";
 import { ServiceError } from "@ddadaal/tsgrpc-common";
-import { JobInfo } from "@scow/ai-scheduler-adapter-protos/build/protos/job";
+import { JobInfo, JobInfo_PodStatus } from "@scow/ai-scheduler-adapter-protos/build/protos/job";
 import { AppType } from "@scow/config/build/appForAi";
 import { getPlaceholderKeys } from "@scow/lib-config/build/parse";
 import { OperationResult, OperationType } from "@scow/lib-operation-log";
@@ -502,6 +502,7 @@ export const createAppSession = procedure
         // 用户指定应用工作目录，如果不存在，则默认为用户的appJobsDirectory
         workingDirectory: workingDirectory ?? join(homeDir, appJobsDirectory),
         script: remoteEntryPath,
+        envVariables: [],
         // 对于AI模块，需要传递的额外参数
         // 第一个参数确定是创建应用or训练任务，
         // 第二个参数为创建应用时的appId
@@ -686,8 +687,18 @@ export const saveImage =
           });
         }
 
-        const nodeName = job.containerJobInfo?.nodeName;
-        const containerId = job.containerJobInfo?.containerId;
+        // 查找运行中的Pod
+        const runningPod = job.pods.find((pod) => pod.podStatus === JobInfo_PodStatus.RUNNING);
+
+        if (!runningPod) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "No running pod found for this job",
+          });
+        }
+
+        const nodeName = runningPod.nodeName;
+        const containerId = runningPod.containerId;
 
         if (!nodeName || !containerId) {
           throw new TRPCError({

--- a/apps/ai/src/server/trpc/route/jobs/jobs.ts
+++ b/apps/ai/src/server/trpc/route/jobs/jobs.ts
@@ -256,6 +256,7 @@ procedure
             // 如果nodeCount不为1但同时选定镜像又没有框架标签，该接口会报错
             (nodeCount === 1 && !gpuType?.startsWith("huawei.com")) ? "" : framework || "",
           ],
+          envVariables:[],
           psNodeCount:psNodes,
           workerNodeCount:workerNodes,
         }).catch((e) => {


### PR DESCRIPTION
### 修复 ai 模块 CI 构建失败的问题
1. 将 jobShell.ts 中 Pod 信息的获取逻辑
2. 调整 namespace 和 podName 的取值逻辑
3. 添加缺少参数（目前默认传的是空数组）

### 备注
- 本次修改只影响 `ai` 模块，不会对其他模块逻辑造成影响